### PR TITLE
Generate tags from version output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ on:
         description: 'Push image to Docker Hub'
         type: boolean
 env:
+  GODOT_REPO: godot-repo
   GODOT_FILENAME: godot
 
 jobs:
@@ -48,7 +49,7 @@ jobs:
         if: github.event.inputs.use-cached-build == 'true'
         uses: actions/cache/restore@v4
         with:
-          path: "godot/bin/${{ env.GODOT_FILENAME }}"
+          path: "${{ env.GODOT_FILENAME }}"
           key: "godot_${{ github.event.inputs.build-commit }}"
 
 
@@ -74,33 +75,32 @@ jobs:
       - name: Build Godot
         if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/godotengine/godot.git
-          cd godot
+          git clone https://github.com/godotengine/godot.git ${{ env.GODOT_REPO}}
+          cd ${{ env.GODOT_REPO}}
           git checkout ${{ github.event.inputs.build-commit }}
-          cd -
-          scons -C godot ${{ github.event.inputs.scons-args }}
-          mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
+          scons -C . ${{ github.event.inputs.scons-args }}
+          mv ./bin/godot.linuxbsd.editor.x86_64 ~/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
         if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: "godot/bin/${{ env.GODOT_FILENAME }}"
+          path: "${{ env.GODOT_FILENAME }}"
           key: "godot_${{ github.event.inputs.build-commit }}"
 
       - name: Get Godot version
         id: godot-version
         run: |
-          echo "Godot version: $(godot/bin/${{ env.GODOT_FILENAME }} --version)"
+          echo "Godot version: $(./${{ env.GODOT_FILENAME }} --version)"
 
-          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\1/')
+          GODOT_VERSION=$(echo $(./${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\1/')
           if [[ -z "$GODOT_VERSION" ]]; then
             echo "::error::Failed to match Godot version, check that the regex can match the version string."
             exit 1
           fi
 
           GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "^[[:digit:]]\.[[:digit:]]")
-          RELEASE_TYPE=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\2/')
+          RELEASE_TYPE=$(echo $(./${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\2/')
 
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: "Godot ${{ steps.godot-version.outputs.version }}"
-          path: "godot/bin/${{ env.GODOT_FILENAME }}"
+          path: "${{ env.GODOT_FILENAME }}"
           if-no-files-found: error
           retention-days: 3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
           key: "godot_${{ github.event.inputs.build-commit }}"
 
       - name: Install dependencies
-        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
+        # NOTE: Check Dockerfile for libraries that need to be present at minimum
+        # for Godot to work is using a cached build
         run: |
           apk add --no-cache \
             scons \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
           key: "godot_${{ github.event.inputs.build-commit }}"
 
       - name: Install dependencies
-        # NOTE: Check Dockerfile for libraries that need to be present at minimum
-        # for Godot to work is using a cached build
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         run: |
           apk add --no-cache \
             scons \
@@ -71,6 +70,14 @@ jobs:
             alsa-lib-dev \
             pulseaudio-dev \
             fontconfig-dev \
+
+      - name: Install dependencies (cached build only)
+        if: github.event.inputs.use-cached-build == 'true' || steps.restore.outputs.cache-hit == 'true'
+        # NOTE: These need to match with the Dockerfile
+        run: |
+          apk add --no-cache \
+            fontconfig \
+            eudev-dev
 
       - name: Build Godot
         if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
@@ -103,6 +110,8 @@ jobs:
 
           GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "^[[:digit:]]\.[[:digit:]]")
           RELEASE_TYPE=$(echo $(./${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\2/')
+
+          echo "Release type: $RELEASE_TYPE"
 
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,17 @@ jobs:
             tar \
             zstd \
 
+      - name: Restore cached build
+        id: restore
+        if: github.event.inputs.use-cached-build == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: "godot/bin/${{ env.GODOT_FILENAME }}"
+          key: "godot_${{ github.event.inputs.build-commit }}"
+
+
       - name: Install dependencies
-        if: github.event.inputs.use-cached-build == 'false'
+        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
         run: |
           apk add --no-cache \
             scons \
@@ -63,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: github.event.inputs.use-cached-build == 'false'
+        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -71,6 +80,13 @@ jobs:
           cd -
           scons -C godot ${{ github.event.inputs.scons-args }}
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
+
+      - name: Cache Godot
+        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
+        uses: actions/cache/save@v4
+        with:
+          path: "godot/bin/${{ env.GODOT_FILENAME }}"
+          key: "godot_${{ github.event.inputs.build-commit }}"
 
       - name: Get Godot version
         id: godot-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false'
+        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'false' }}
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build & Publish Godot
+run-name: "${{ github.workflow }}"
 on:
   workflow_dispatch:
     inputs:
-      version-tag:
-        description: 'Version tag shown in releases and in Docker Hub'
-        required: true
       build-commit:
         description: 'Commit, tag, or branch to build'
         required: true
@@ -19,9 +17,7 @@ on:
         description: 'Push image to Docker Hub'
         type: boolean
 env:
-  CACHE_GODOT: cache_godot_${{ github.event.inputs.version-tag }}
   GODOT_FILENAME: godot
-run-name: ${{ github.workflow }} ${{ github.event.inputs.version-tag }}
 
 jobs:
   build:
@@ -30,6 +26,7 @@ jobs:
       image: alpine:latest
     outputs:
       godot-version: ${{ steps.godot-version.outputs.version }}
+      godot-major-minor-version: ${{ steps.godot-version.outputs.major-minor-version }}
     defaults:
       run:
         shell: ash {0}
@@ -42,15 +39,7 @@ jobs:
             tar \
             zstd \
 
-      - name: Cache Godot
-        id: cache-godot
-        uses: actions/cache@v4
-        with:
-          path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
-          key: ${{ env.CACHE_GODOT }}
-
       - name: Install dependencies
-        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
           apk add --no-cache \
             scons \
@@ -69,7 +58,6 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -78,19 +66,28 @@ jobs:
           scons -C godot ${{ github.event.inputs.scons-args }}
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
-      - name: Store Godot version in outputs
+      - name: Get Godot version
         id: godot-version
         run: |
-          GODOT_VERSION=$(godot/bin/${{ env.GODOT_FILENAME }} --version)
+          GODOT_VERSION=$(godot/bin/${{ env.GODOT_FILENAME }} --version | grep -o "[[:digit:]].[[:digit:]].[[:digit:]]")
+          GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "[[:digit:]].[[:digit:]]")
+          echo $GODOT_VERSION
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Zip Godot
-        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
           cd godot/bin/
-          zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}
+          zip ${{ env.GODOT_FILENAME }}.zip ${{ env.GODOT_FILENAME }}
           cd -
-          mv godot/bin/${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
+          mv godot/bin/${{ env.GODOT_FILENAME }}.zip ${{ env.GODOT_FILENAME }}.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "Godot ${{ steps.godot-version.outputs.version }}"
+          path: ${{ env.GODOT_FILENAME }}.zip
+          if-no-files-found: error
+          retention-days: 3
 
   print-godot-version:
     needs: build
@@ -98,26 +95,24 @@ jobs:
     steps:
       - run: |
           echo "Godot version: ${{ needs.build.outputs.godot-version }}"
+          echo "Godot major-minor version: ${{ needs.build.outputs.godot-major-minor-version }}"
 
   release:
     if: github.event.inputs.release-binary == 'true'
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Godot
-        id: cache-godot
-        uses: actions/cache@v4
+      - uses: actions/download-artifact@v4
         with:
-          path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
-          key: ${{ env.CACHE_GODOT }}
+          name: "Godot ${{ needs.build.outputs.godot-version }}"
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Godot v${{ github.event.inputs.version-tag }} for Alpine Linux
-          body: Godot v${{ github.event.inputs.version-tag }} for Alpine Linux
-          tag_name: v${{ github.event.inputs.version-tag }}
-          files: ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
+          name: Godot v${{ needs.build.outputs.godot-version }} for Alpine Linux
+          body: Godot v${{ needs.build.outputs.godot-version }} for Alpine Linux
+          tag_name: v${{ needs.build.outputs.godot-version }}
+          files: ${{ env.GODOT_FILENAME }}.zip
 
   docker:
     if: github.event.inputs.publish-image == 'true'
@@ -127,23 +122,22 @@ jobs:
       dockerhub_username: ${{ secrets.dockerhub_username }}
       dockerhub_password: ${{ secrets.dockerhub_password }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Cache Godot
-        id: cache-godot
-        uses: actions/cache@v4
+      - uses: actions/download-artifact@v4
         with:
-          path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
-          key: ${{ env.CACHE_GODOT }}
+          name: "Godot ${{ needs.build.outputs.godot-version }}"
 
       - name: Unzip godot
-        run: unzip ./godot_${{ github.event.inputs.version-tag }}.zip
+        run: unzip ./${{ env.GODOT_FILENAME }}.zip
 
       - name: Login
         run: docker login -u "$dockerhub_username" -p "$dockerhub_password"
 
-      - name: Build container
-        run: docker build -t aronand/godot-alpine:${{ github.event.inputs.version-tag }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
+      - name: Build and tag image
+        run: |
+          docker build -t aronand/godot-alpine:${{ needs.build.outputs.godot-version }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
+          docker image tag aronand/godot-alpine:${{ needs.build.outputs.godot-major-minor-version}}-latest-patch
 
       - name: Push image to Docker Hub
-        run: docker push aronand/godot-alpine:${{ github.event.inputs.version-tag }}
+        run: docker push aronand/godot-alpine:${{ needs.build.outputs.godot-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,9 +160,6 @@ jobs:
         with:
           name: "Godot ${{ needs.build.outputs.godot-version }}"
 
-      - name: Unzip godot
-        run: unzip ./${{ env.GODOT_FILENAME }}.zip
-
       - name: Login
         run: docker login -u "$dockerhub_username" -p "$dockerhub_password"
 
@@ -174,4 +171,4 @@ jobs:
           fi
 
       - name: Push image to Docker Hub
-        run: docker push aronand/godot-alpine:${{ needs.build.outputs.godot-version }}
+        run: docker push aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,4 +172,4 @@ jobs:
           fi
 
       - name: Push image to Docker Hub
-        run: docker push aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
+        run: docker push --all-tags aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,9 +111,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: "Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux"
-          body: "Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux"
-          tag_name: "v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}"
+          name: Godot v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}" for Alpine Linux
+          body: Godot v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}" for Alpine Linux
+          tag_name: v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}"
           files: ${{ env.GODOT_FILENAME }}.zip
 
   # TODO: Fix push, verify that the -latest-patch tag is getting applied

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,9 +165,10 @@ jobs:
 
       - name: Build and tag image
         run: |
-          docker build -t aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
+          IMAGE_TAG=aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
+          docker build -t "$IMAGE_TAG" --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
           if [ "${{ needs.build.outputs.release-type }}" == "stable" ]; then
-            docker image tag aronand/godot-alpine:${{ needs.build.outputs.godot-major-minor-version}}-latest-patch
+            docker image tag $IMAGE_TAG aronand/godot-alpine:${{ needs.build.outputs.godot-major-minor-version}}-latest-patch
           fi
 
       - name: Push image to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
           path: "${{ env.GODOT_FILENAME }}"
           key: "godot_${{ github.event.inputs.build-commit }}"
 
-
       - name: Install dependencies
         if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
         run: |
@@ -79,7 +78,8 @@ jobs:
           cd ${{ env.GODOT_REPO}}
           git checkout ${{ github.event.inputs.build-commit }}
           scons -C . ${{ github.event.inputs.scons-args }}
-          mv ./bin/godot.linuxbsd.editor.x86_64 ~/${{ env.GODOT_FILENAME }}
+          cd -
+          mv "${{ env.GODOT_REPO }}/bin/godot.linuxbsd.editor.x86_64" "${{ env.GODOT_FILENAME }}"
 
       - name: Cache Godot
         if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit != 'true'
@@ -90,6 +90,7 @@ jobs:
 
       - name: Get Godot version
         id: godot-version
+        # TODO: Experiment with ripgrep as it seems to support capture groups
         run: |
           echo "Godot version: $(./${{ env.GODOT_FILENAME }} --version)"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build & Publish Godot
-run-name: "Build${{ inputs.release-binary && ', release'}}${{ inputs.publish-image && ', publish'}}"
+run-name: "Build ${{ inputs.build-commit }} ${{ inputs.release-binary && ', release' || '' }}${{ inputs.publish-image && ', publish' || ''}}"
 on:
   workflow_dispatch:
     inputs:
@@ -27,6 +27,7 @@ jobs:
     outputs:
       godot-version: ${{ steps.godot-version.outputs.version }}
       godot-major-minor-version: ${{ steps.godot-version.outputs.major-minor-version }}
+      release-type: ${{ steps.godot-version.outputs.release_type }}
     defaults:
       run:
         shell: ash {0}
@@ -71,16 +72,18 @@ jobs:
         run: |
           echo "Godot version: $(godot/bin/${{ env.GODOT_FILENAME }} --version)"
 
-          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)(\.[[:alnum:]]*\.[[:alpha:]]*\.[[:alnum:]]*)$/\1/')
+          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]]*\.[[:alnum:]]*/\1/')
           if [[ -z "$GODOT_VERSION" ]]; then
             echo "::error::Failed to match Godot version, check that the regex can match the version string."
             exit 1
           fi
 
           GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "^[[:digit:]]\.[[:digit:]]")
+          RELEASE_TYPE=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]]*\.[[:alnum:]]*/\2/')
 
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release-type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
 
       - name: Zip Godot
         run: |
@@ -116,9 +119,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Godot v${{ needs.build.outputs.godot-version }} for Alpine Linux
-          body: Godot v${{ needs.build.outputs.godot-version }} for Alpine Linux
-          tag_name: v${{ needs.build.outputs.godot-version }}
+          name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
+          body: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
+          tag_name: v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
           files: ${{ env.GODOT_FILENAME }}.zip
 
   docker:
@@ -143,8 +146,10 @@ jobs:
 
       - name: Build and tag image
         run: |
-          docker build -t aronand/godot-alpine:${{ needs.build.outputs.godot-version }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
-          docker image tag aronand/godot-alpine:${{ needs.build.outputs.godot-major-minor-version}}-latest-patch
+          docker build -t aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
+          if [ "${{ needs.build.outputs.release-type }}" == "stable" ]; then
+            docker image tag aronand/godot-alpine:${{ needs.build.outputs.godot-major-minor-version}}-latest-patch
+          fi
 
       - name: Push image to Docker Hub
         run: docker push aronand/godot-alpine:${{ needs.build.outputs.godot-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       godot-version: ${{ steps.godot-version.outputs.version }}
       godot-major-minor-version: ${{ steps.godot-version.outputs.major-minor-version }}
-      release-type: ${{ steps.godot-version.outputs.release_type }}
+      release-type: ${{ steps.godot-version.outputs.release-type }}
     defaults:
       run:
         shell: ash {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,15 @@ jobs:
         with:
           name: "Godot ${{ needs.build.outputs.godot-version }}"
 
+      - name: Debugging
+        run: |
+          echo "Godot version: ${{ needs.build.outputs.godot-version }}"
+          echo "Release type: ${{ needs.build.outputs.release-type }}"
+          COMBINED="${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}"
+          echo "$COMBINED"
+
       - name: Release
+        if: ${{ 1 == 2 }}
         uses: softprops/action-gh-release@v2
         with:
           name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,14 +99,6 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-  print-godot-version:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Godot version: ${{ needs.build.outputs.godot-version }}"
-          echo "Godot major-minor version: ${{ needs.build.outputs.godot-major-minor-version }}"
-
   release:
     if: github.event.inputs.release-binary == 'true'
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,11 +111,12 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
-          body: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
-          tag_name: v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
+          name: "Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux"
+          body: "Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux"
+          tag_name: "v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}"
           files: ${{ env.GODOT_FILENAME }}.zip
 
+  # TODO: Fix push, verify that the -latest-patch tag is getting applied
   docker:
     if: github.event.inputs.publish-image == 'true'
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,6 @@ jobs:
           tag_name: v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
           files: ${{ env.GODOT_FILENAME }}-${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}.zip
 
-  # TODO: Fix push, verify that the -latest-patch tag is getting applied
   docker:
     if: github.event.inputs.publish-image == 'true'
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,13 +133,16 @@ jobs:
         with:
           name: "Godot ${{ needs.build.outputs.godot-version }}"
 
+      - name: Zip binary
+        run: zip ${{ env.GODOT_FILENAME }}-${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}.zip ${{ env.GODOT_FILENAME }}
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
           body: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
           tag_name: v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
-          files: ${{ env.GODOT_FILENAME }}
+          files: ${{ env.GODOT_FILENAME }}-${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}.zip
 
   # TODO: Fix push, verify that the -latest-patch tag is getting applied
   docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,8 @@ jobs:
         run: zip ${{ env.GODOT_FILENAME }}-${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}.zip ${{ env.GODOT_FILENAME }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        # TODO: Update version when 2.3.0 is fixed (see: https://github.com/softprops/action-gh-release/issues/628)
+        uses: softprops/action-gh-release@v2.2.2
         with:
           name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
           body: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: alpine:latest
+    outputs:
+      godot-version: ${{ steps.godot-version.outputs.version }}
     defaults:
       run:
         shell: ash {0}
@@ -75,7 +77,12 @@ jobs:
           cd -
           scons -C godot ${{ github.event.inputs.scons-args }}
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
-          godot/bin/${{ env.GODOT_FILENAME }} --version
+
+      - name: Store Godot version in outputs
+        id: godot-version
+        run: |
+          GODOT_VERSION=$(godot/bin/${{ env.GODOT_FILENAME }} --version)
+          echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Zip Godot
         if: steps.cache-godot.outputs.cache-hit != 'true'
@@ -84,6 +91,13 @@ jobs:
           zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}
           cd -
           mv godot/bin/${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
+
+  print-godot-version:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Godot version: ${{ needs.build.outputs.godot-version }}"
 
   release:
     if: github.event.inputs.release-binary == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
         description: 'Arguments passed to scons to build the editor'
         required: true
         default: 'platform=linuxbsd production=yes target=editor execinfo=no'
+      use-cached-build:
+        description: 'Use cached build'
+        type: boolean
       release-binary:
         description: 'Add binary to releases'
         type: boolean
@@ -41,6 +44,7 @@ jobs:
             zstd \
 
       - name: Install dependencies
+        if: github.event.inputs.use-cached-build == 'false'
         run: |
           apk add --no-cache \
             scons \
@@ -59,6 +63,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
+        if: github.event.inputs.use-cached-build == 'false'
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -85,17 +90,10 @@ jobs:
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
           echo "release-type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
 
-      - name: Zip Godot
-        run: |
-          cd godot/bin/
-          zip ${{ env.GODOT_FILENAME }}.zip ${{ env.GODOT_FILENAME }}
-          cd -
-          mv godot/bin/${{ env.GODOT_FILENAME }}.zip ${{ env.GODOT_FILENAME }}.zip
-
       - uses: actions/upload-artifact@v4
         with:
           name: "Godot ${{ steps.godot-version.outputs.version }}"
-          path: ${{ env.GODOT_FILENAME }}.zip
+          path: "godot/bin/${{ env.GODOT_FILENAME }}"
           if-no-files-found: error
           retention-days: 3
 
@@ -111,10 +109,10 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Godot v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}" for Alpine Linux
-          body: Godot v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}" for Alpine Linux
-          tag_name: v"${{ needs.build.outputs.godot-version }}"-"${{ needs.build.outputs.release-type }}"
-          files: ${{ env.GODOT_FILENAME }}.zip
+          name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
+          body: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux
+          tag_name: v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
+          files: ${{ env.GODOT_FILENAME }}
 
   # TODO: Fix push, verify that the -latest-patch tag is getting applied
   docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Install dependencies (cached build only)
-        if: github.event.inputs.use-cached-build == 'true' || steps.restore.outputs.cache-hit == 'true'
+        if: github.event.inputs.use-cached-build == 'true' && steps.restore.outputs.cache-hit == 'true'
         # NOTE: These need to match with the Dockerfile
         run: |
           apk add --no-cache \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,14 @@ jobs:
             zip \
             tar \
             zstd \
+
       - name: Cache Godot
         id: cache-godot
         uses: actions/cache@v4
         with:
           path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
           key: ${{ env.CACHE_GODOT }}
+
       - name: Install dependencies
         if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
@@ -63,6 +65,7 @@ jobs:
             alsa-lib-dev \
             pulseaudio-dev \
             fontconfig-dev \
+
       - name: Build Godot
         if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
@@ -72,6 +75,8 @@ jobs:
           cd -
           scons -C godot ${{ github.event.inputs.scons-args }}
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
+          godot/bin/${{ env.GODOT_FILENAME }} --version
+
       - name: Zip Godot
         if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
@@ -79,6 +84,7 @@ jobs:
           zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}
           cd -
           mv godot/bin/${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
+
   release:
     if: github.event.inputs.release-binary == 'true'
     needs: build
@@ -90,6 +96,7 @@ jobs:
         with:
           path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
           key: ${{ env.CACHE_GODOT }}
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -97,6 +104,7 @@ jobs:
           body: Godot v${{ github.event.inputs.version-tag }} for Alpine Linux
           tag_name: v${{ github.event.inputs.version-tag }}
           files: ${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
+
   docker:
     if: github.event.inputs.publish-image == 'true'
     needs: build
@@ -106,17 +114,22 @@ jobs:
       dockerhub_password: ${{ secrets.dockerhub_password }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Cache Godot
         id: cache-godot
         uses: actions/cache@v4
         with:
           path: ./${{ env.GODOT_FILENAME }}_${{ github.event.inputs.version-tag }}.zip
           key: ${{ env.CACHE_GODOT }}
+
       - name: Unzip godot
         run: unzip ./godot_${{ github.event.inputs.version-tag }}.zip
+
       - name: Login
         run: docker login -u "$dockerhub_username" -p "$dockerhub_password"
+
       - name: Build container
         run: docker build -t aronand/godot-alpine:${{ github.event.inputs.version-tag }} --build-arg GODOT_FILENAME=${{ env.GODOT_FILENAME }} .
+
       - name: Push image to Docker Hub
         run: docker push aronand/godot-alpine:${{ github.event.inputs.version-tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build & Publish Godot
-run-name: "${{ github.workflow }}"
+run-name: "Build${{ inputs.release-binary && ', release'}}${{ inputs.publish-image && ', publish'}}"
 on:
   workflow_dispatch:
     inputs:
@@ -69,9 +69,16 @@ jobs:
       - name: Get Godot version
         id: godot-version
         run: |
-          GODOT_VERSION=$(godot/bin/${{ env.GODOT_FILENAME }} --version | grep -o "[[:digit:]].[[:digit:]].[[:digit:]]")
-          GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "[[:digit:]].[[:digit:]]")
-          echo $GODOT_VERSION
+          echo "Godot version: $(godot/bin/${{ env.GODOT_FILENAME }} --version)"
+
+          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)(\.[[:alnum:]]*\.[[:alpha:]]*\.[[:alnum:]]*)$/\1/')
+          if [[ -z "$GODOT_VERSION" ]]; then
+            echo "::error::Failed to match Godot version, check that the regex can match the version string."
+            exit 1
+          fi
+
+          GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "^[[:digit:]]\.[[:digit:]]")
+
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,15 +133,7 @@ jobs:
         with:
           name: "Godot ${{ needs.build.outputs.godot-version }}"
 
-      - name: Debugging
-        run: |
-          echo "Godot version: ${{ needs.build.outputs.godot-version }}"
-          echo "Release type: ${{ needs.build.outputs.release-type }}"
-          COMBINED="${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}"
-          echo "$COMBINED"
-
       - name: Release
-        if: ${{ 1 == 2 }}
         uses: softprops/action-gh-release@v2
         with:
           name: Godot v${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }} for Alpine Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' && steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,14 +72,14 @@ jobs:
         run: |
           echo "Godot version: $(godot/bin/${{ env.GODOT_FILENAME }} --version)"
 
-          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]]*\.[[:alnum:]]*/\1/')
+          GODOT_VERSION=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\1/')
           if [[ -z "$GODOT_VERSION" ]]; then
             echo "::error::Failed to match Godot version, check that the regex can match the version string."
             exit 1
           fi
 
           GODOT_MAJOR_MINOR_VERSION=$(echo $GODOT_VERSION | grep -o "^[[:digit:]]\.[[:digit:]]")
-          RELEASE_TYPE=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]]*\.[[:alnum:]]*/\2/')
+          RELEASE_TYPE=$(echo $(godot/bin/${{ env.GODOT_FILENAME }} --version) | sed -E 's/^(.*)\.([[:alnum:]]*)\.[[:alpha:]\_]*\.[[:alnum:]]*/\2/')
 
           echo "version=$GODOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major-minor-version=$GODOT_MAJOR_MINOR_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
+        if: github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false'
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Install dependencies
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
         run: |
           apk add --no-cache \
             scons \
@@ -72,7 +72,7 @@ jobs:
             fontconfig-dev \
 
       - name: Build Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
         run: |
           git clone https://github.com/godotengine/godot.git
           cd godot
@@ -82,7 +82,7 @@ jobs:
           mv godot/bin/godot.linuxbsd.editor.x86_64 godot/bin/${{ env.GODOT_FILENAME }}
 
       - name: Cache Godot
-        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'true' }}
+        if: ${{ github.event.inputs.use-cached-build == 'false' || steps.restore.outputs.cache-hit == 'false' }}
         uses: actions/cache/save@v4
         with:
           path: "godot/bin/${{ env.GODOT_FILENAME }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,4 +172,4 @@ jobs:
           fi
 
       - name: Push image to Docker Hub
-        run: docker push --all-tags aronand/godot-alpine:${{ needs.build.outputs.godot-version }}-${{ needs.build.outputs.release-type }}
+        run: docker push --all-tags aronand/godot-alpine


### PR DESCRIPTION
- Replaces cache with artifacts
  - Cache still used to store build output, used conditionally (`use-cached-build` input)
- Stores version information from `godot --version` as output and uses said output to generate version tags to GitHub and Docker Hub 

Closes #4 